### PR TITLE
fixed Qiniu::RS.put_file()

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiniu-rs (2.3.0)
+    qiniu-rs (2.3.1)
       json (~> 1.7.3)
       mime-types (~> 1.19)
       rest-client (~> 1.6.7)
@@ -12,7 +12,7 @@ GEM
   specs:
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
-    json (1.7.3)
+    json (1.7.4)
     mime-types (1.19)
     rake (0.9.2.2)
     rest-client (1.6.7)

--- a/lib/qiniu/rs/auth.rb
+++ b/lib/qiniu/rs/auth.rb
@@ -58,17 +58,17 @@ module Qiniu
           [code, data]
         end
 
-        def call_with_signature(url, data, retry_times = 0)
-          code, data = http_request url, data, {:qbox_signature_token => generate_qbox_signature(url, data)}
+        def call_with_signature(url, data, retry_times = 0, options = {})
+          code, data = http_request url, data, options.merge!({:qbox_signature_token => generate_qbox_signature(url, data)})
           [code, data]
         end
 
-        def request(url, data = nil)
+        def request(url, data = nil, options = {})
           begin
             if Config.settings[:access_key].empty? || Config.settings[:secret_key].empty?
               code, data = Auth.call_with_logged_in(url, data)
             else
-              code, data = Auth.call_with_signature(url, data)
+              code, data = Auth.call_with_signature(url, data, options)
             end
           rescue [MissingAccessToken, MissingRefreshToken, MissingUsernameOrPassword] => e
             Log.logger.error e

--- a/lib/qiniu/rs/io.rb
+++ b/lib/qiniu/rs/io.rb
@@ -30,9 +30,8 @@ module Qiniu
         def put_file(local_file, bucket, key = nil, mime_type = nil, custom_meta = nil, enable_crc32_check = false)
           action_params = _generate_action_params(local_file, bucket, key, mime_type, custom_meta, enable_crc32_check)
           url = Config.settings[:io_host] + action_params
-          post_data = {:file => File.new(local_file, 'rb'), :multipart => true}
-          options = {:qbox_signature_token => Utils.generate_qbox_signature(url, nil)}
-          Utils.send_multipart_request url, post_data, options
+          options = {:content_type => 'application/octet-stream'}
+          Auth.request url, ::IO.read(local_file), options
         end
 
         private

--- a/lib/qiniu/rs/version.rb
+++ b/lib/qiniu/rs/version.rb
@@ -2,6 +2,6 @@
 
 module Qiniu
   module RS
-    VERSION = "2.3.0"
+    VERSION = "2.3.1"
   end
 end


### PR DESCRIPTION
原来 put_file 上传的文件流是 multipart ，会导致文件上传到服务端后 content-length 变长，实际上根据我们的服务端应传  binary 。已修正并通过单元测试。
