### PR TITLE
修正 Qiniu::RS.generate_upload_toke 对参数处理和文档描述不一致

### DIFF
--- a/lib/qiniu/tokens/upload_token.rb
+++ b/lib/qiniu/tokens/upload_token.rb
@@ -14,7 +14,7 @@ module Qiniu
 
         def initialize(opts = {})
           @scope = opts[:scope]
-          @expires_in = opts[:expires_in]
+          @expires_in = opts[:expires_in] || 3600
           @callback_url = opts[:callback_url]
           @callback_body_type = opts[:callback_body_type]
           @customer = opts[:customer]

--- a/spec/qiniu/rs_spec.rb
+++ b/spec/qiniu/rs_spec.rb
@@ -115,7 +115,7 @@ module Qiniu
 
     context ".upload_file" do
       it "should works" do
-        uptoken_opts = {:scope => @bucket, :expires_in => 3600}
+        uptoken_opts = {:scope => @bucket}
         upload_opts = {
           :uptoken => Qiniu::RS.generate_upload_token(uptoken_opts),
           :file => __FILE__,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
   config.before :all do
 #=begin
     Qiniu::RS.establish_connection! :access_key => "3fPHl_SLkPXdioqI_A8_NGngPWVJhlDk2ktRjogH",
-                                    :secret_key => "bXTPMDJrVYRJUiSDRFtFYwycVD_mjXxYWrCYlDHy",
+                                    :secret_key => "bXTPMDJrVYRJUiSDRFtFYwycVD_mjXxYWrCYlDHy"
 #=end
 =begin
     Qiniu::RS.establish_connection! :access_key => "bE21M6FW9V7zAFrBY5psgKOKJQLiBj12qMWTpc57",


### PR DESCRIPTION
文档中描述 `Qiniu::RS.generate_upload_toke`  的参数 `:expires_in`为可选,默认值为3600,但代码中实际的处理并没有考虑参数未传值时取默认值,所以该版本的 Gem 在使用时如果不传入 `:expires_in` ,则会报如下错误

```
TypeError:
       nil can't be coerced into Bignum
```

ref: http://docs.qiniutek.com/v3/sdk/ruby/#upload
