### PR TITLE
Fixes Qiniu::RS::Exception Issue

### DIFF
--- a/lib/qiniu/rs/exceptions.rb
+++ b/lib/qiniu/rs/exceptions.rb
@@ -4,9 +4,6 @@ module Qiniu
   module RS
 
     class Exception < RuntimeError
-      def to_s
-        inspect
-      end
     end
 
     class ResponseError < Exception


### PR DESCRIPTION
This causes infinite recursion for Ruby 1.9.3, probably because "inspect" calls "to_s"
