### PR TITLE
remove `key` extraction

### DIFF
--- a/lib/qiniu/upload.rb
+++ b/lib/qiniu/upload.rb
@@ -86,9 +86,6 @@ module Qiniu
                                  key = nil,
                                  x_vars = nil)
         uptoken = Auth.generate_uptoken(put_policy)
-        if key.nil? then
-          key = put_policy.key
-        end
 
         return upload_with_token_2(uptoken, local_file, key, x_vars)
       end # upload_with_put_policy


### PR DESCRIPTION
- 这里提到上传时 key 不是必须的 http://developer.qiniu.com/docs/v6/api/reference/up/upload.html
- 这里提到 putpolicy 里面没有 key，只有 saveKey，但是 saveKey 是能包含魔法变量的，上传时的 key 不能包含，故不能用前者代替后者 http://developer.qiniu.com/docs/v6/api/reference/security/put-policy.html
- 实际使用中确实是这样： 发送 post 请求时不带 key, 但是 put-policy 里面有 key ，依然能成功上传。
