### PR TITLE
have bug with gem qiniu-rs, so delete it being well.

### DIFF
--- a/lib/qiniu-rs.rb
+++ b/lib/qiniu-rs.rb
@@ -1,2 +1,0 @@
-# More logical way to require 'qiniu-rs'
-require File.join(File.dirname(__FILE__), 'qiniu', 'qiniu')


### PR DESCRIPTION
> ruby gem bao   qiniu 和 qiniu-rs 一起装的话， 
> require 'qiniu-rs', 这样ruby会先去引入 qiniu 包下的  qiniu-rs.rb文件,可能是排序在前的缘故。
> 建议删除他吧。
