### PR TITLE
修复了 Qiniu::Auth#authorize_download_url_2 中 key 被错误的 escape 的问题

### DIFF
--- a/lib/qiniu/auth.rb
+++ b/lib/qiniu/auth.rb
@@ -3,7 +3,6 @@
 
 require 'hmac-sha1'
 require 'uri'
-require 'cgi'
 
 require 'qiniu/exceptions'
 
@@ -193,7 +192,7 @@ module Qiniu
 
         ### 对包含中文或其它 utf-8 字符的 Key 做下载授权
         def authorize_download_url_2(domain, key, args = EMPTY_ARGS)
-          url_encoded_key = CGI::escape(key)
+          url_encoded_key = URI::escape(key)
 
           schema = args[:schema] || "http"
           port   = args[:port]


### PR DESCRIPTION
在 authorize_download_url_2 中 key 是被 CGI escape 的而非 URI escape，虽然在很多情况下这样的 URL 依然可以访问，但是可能导致 CDN 无法正确缓存这样的 URL