### PR TITLE
Update rest-client dependency to 2.0.0, and update json dependency

### DIFF
--- a/qiniu.gemspec
+++ b/qiniu.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", ">= 2.11"
   gem.add_development_dependency "fakeweb", "~> 1.3"
   gem.add_runtime_dependency "json", "~> 1.8"
-  gem.add_runtime_dependency "rest-client", "~> 1.8.0"
+  gem.add_runtime_dependency "rest-client", "~> 2.0.0"
   gem.add_runtime_dependency "mime-types", ">= 2.4.0"
   gem.add_runtime_dependency "ruby-hmac", "~> 0.4"
   gem.add_runtime_dependency "jruby-openssl", "~> 0.7" if RUBY_PLATFORM == "java"

--- a/qiniu.gemspec
+++ b/qiniu.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9"
   gem.add_development_dependency "rspec", ">= 2.11"
   gem.add_development_dependency "fakeweb", "~> 1.3"
-  gem.add_runtime_dependency "json", "~> 1.8"
+  gem.add_runtime_dependency "json", ">= 1.8"
   gem.add_runtime_dependency "rest-client", "~> 2.0.0"
   gem.add_runtime_dependency "mime-types", ">= 2.4.0"
   gem.add_runtime_dependency "ruby-hmac", "~> 0.4"


### PR DESCRIPTION
`rest-client` 1.8.0 seems to have a memory leak.
I'm not sure how to exactly determine whether it has a memory leak, but according to the following simple test, 2.0.0 uses much less memory and time than 1.8.0.

```
#!/usr/bin/env ruby
# ruby 2.3.1

gem 'rest-client', '~> 1.8.0'
#gem 'rest-client', '~> 2.0.0'
require 'rest-client'

puts RestClient::VERSION

start_time = Time.now

10000.times do
 # just an empty file behind nginx
  RestClient.get '127.0.0.1/test.html'
end

end_time = Time.now

GC.start
sleep 10

puts 'Memory: ' + `ps -p #{Process.pid} -o %mem | tail -1`.strip + '%'
puts "Time: #{end_time - start_time}s"
```
I find this when trying to address the memory leaks in my rails application. One api that use `rest-client` causes the memory usage grows continuously. If using `rest-client` 2.0.0, the memory usage will stop growing after reaching a fixed value.

`rest-client` 2.0.0 is largely API compatible with 1.8.0, and qiniu should work correctly with it. See `rest-client` [history](https://github.com/rest-client/rest-client/blob/master/history.md) for more.