### PR TITLE
fixed bucket option when multi_region is enabled exception

### DIFF
--- a/examples/upload.rb
+++ b/examples/upload.rb
@@ -16,7 +16,7 @@ key = 'my-ruby-logo.png'
 #构建上传策略
 put_policy = Qiniu::Auth::PutPolicy.new(
     bucket,      # 存储空间
-    key,     # 最终资源名，可省略，即缺省为“创建”语义，设置为nil为普通上传 
+    key,     # 最终资源名，可省略，即缺省为“创建”语义，设置为nil为普通上传
     3600    #token过期时间，默认为3600s
 )
 
@@ -28,9 +28,11 @@ filePath = './ruby-logo.png'
 
 #调用upload_with_token_2方法上传
 code, result, response_headers = Qiniu::Storage.upload_with_token_2(
-     uptoken, 
+     uptoken,
      filePath,
-     key
+     key,
+	 nil,
+	 :bucket => bucket
 )
 
 #打印上传返回的信息


### PR DESCRIPTION
ruby-2.3.0@global/gems/qiniu-6.8.1/lib/qiniu/upload.rb:84:in `rescue in
upload_with_token_2': upload_with_token_2 requires :bucket option when
multi_region is enabled (RuntimeError)
from gems/qiniu-6.8.1/lib/qiniu/upload.rb:55:in`upload_with_token_2'
from qiniu/qiniu_test.rb:31:in `<top (required)>'
from -e:1:in`load'
from -e:1:in `<main>'
