### PR TITLE
升级依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@
 1. Fork
 2. 创建您的特性分支 (`git checkout -b my-new-feature`)
 3. 提交您的改动 (`git commit -am 'Added some feature'`)
-4. 将您的修改记录提交到远程 `git` 仓库 (`git push origin my-new-feature`)
-5. 然后到 github 网站的该 `git` 远程仓库的 `my-new-feature` 分支下发起 Pull Request
+4. 在你自己的七牛账户里创建 rubysdk 和 rubysdk-bc 两个 bucket
+5. 添加 QINIU_ACCESS_KEY 和 QINIU_SECRET_KEY 两个环境变量
+6. 使用 `bundle exec rake` 来运行测试
+7. 将您的修改记录提交到远程 `git` 仓库 (`git push origin my-new-feature`)
+8. 然后到 github 网站的该 `git` 远程仓库的 `my-new-feature` 分支下发起 Pull Request
 
 ## 许可证
 

--- a/qiniu.gemspec
+++ b/qiniu.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rspec', '~> 2.11'
   gem.add_development_dependency 'fakeweb', '~> 1.3'
-  gem.add_runtime_dependency 'json', '~> 1.8'
+  gem.add_runtime_dependency 'json', '~> 2.0'
   gem.add_runtime_dependency 'rest-client', '~> 2.0', '>= 2.0.0'
-  gem.add_runtime_dependency 'mime-types', '~> 2.4', '>= 2.4.0'
+  gem.add_runtime_dependency 'mime-types', '~> 3.1'
   gem.add_runtime_dependency 'ruby-hmac', '~> 0.4'
   gem.add_runtime_dependency 'jruby-openssl', '~> 0.7' if RUBY_PLATFORM == 'java'
 end

--- a/spec/qiniu/auth_spec.rb
+++ b/spec/qiniu/auth_spec.rb
@@ -18,7 +18,7 @@ module Qiniu
       end
 
       ### 测试私有资源下载
-      context ".download_private_file" do
+      describe ".download_private_file" do
         it "should works" do
           ### 生成Key
           key = 'a_private_file'
@@ -93,7 +93,7 @@ module Qiniu
     end
 
     ### 测试回调签名
-    context ".authenticate_callback_request" do
+    describe ".authenticate_callback_request" do
       it "should works" do
         url = '/test.php'
         body = 'name=xxx&size=1234'
@@ -115,7 +115,7 @@ module Qiniu
   module Exception_Auth
     describe Exception_Auth, :not_set_ak_sk => true do
       ### 测试未设置 ak/sk 的异常抛出情况
-      context ".not_set_ak_sk" do
+      describe ".not_set_ak_sk" do
         it "should works" do
           puts Qiniu::Config.instance_variable_get("@settings").inspect
 


### PR DESCRIPTION
1. 升级依赖
2. 使测试通过
3. 添加测试说明

不过依然有一个测试没通过（改之前也是没通过的）：

```
Failures:

  1) Qiniu::Fop.exif should works
     Failure/Error: result["url"].should_not be_empty
     NoMethodError:
       undefined method `[]' for false:FalseClass
     # ./spec/qiniu/image_spec.rb:65:in `block (3 levels) in <module:Fop>'

Finished in 2 minutes 38.2 seconds
107 examples, 1 failure

Failed examples:

rspec ./spec/qiniu/image_spec.rb:63 # Qiniu::Fop.exif should works
/usr/local/Cellar/ruby/2.3.1/bin/ruby -S rspec spec/qiniu/abstract_spec.rb spec/qiniu/auth_spec.rb spec/qiniu/image_spec.rb spec/qiniu/management_spec.rb spec/qiniu/misc_spec.rb spec/qiniu/pfop_spec.rb spec/qiniu/qiniu_spec.rb spec/qiniu/tokens/qbox_token_spec.rb spec/qiniu/upload_spec.rb spec/qiniu/utils_spec.rb spec/qiniu/version_spec.rb failed
```