### PR TITLE
Fix broken auth spec

### DIFF
--- a/spec/qiniu/auth_spec.rb
+++ b/spec/qiniu/auth_spec.rb
@@ -84,24 +84,24 @@ module Qiniu
           end
         end
       end
-    end
 
-    ### 测试回调签名
-    context ".authenticate_callback_request" do
-      it "should works" do
-        url = '/test.php'
-        body = 'name=xxx&size=1234'
-        false.should == Qiniu::Auth.authenticate_callback_request('ABCD', url, body)
-        false.should == Qiniu::Auth.authenticate_callback_request(Config.settings[:access_key], url, body)
-        false.should == Qiniu::Auth.authenticate_callback_request('QBox ' + Config.settings[:access_key] + ':', url, body)
-        false.should == Qiniu::Auth.authenticate_callback_request('QBox ' + Config.settings[:access_key] + ':????', url, body)
+      ### 测试回调签名
+      context ".authenticate_callback_request" do
+        it "should works" do
+          url = '/test.php'
+          body = 'name=xxx&size=1234'
+          false.should == Qiniu::Auth.authenticate_callback_request('ABCD', url, body)
+          false.should == Qiniu::Auth.authenticate_callback_request(Config.settings[:access_key], url, body)
+          false.should == Qiniu::Auth.authenticate_callback_request('QBox ' + Config.settings[:access_key] + ':', url, body)
+          false.should == Qiniu::Auth.authenticate_callback_request('QBox ' + Config.settings[:access_key] + ':????', url, body)
 
-        acctoken = Qiniu::Auth.generate_acctoken(url, body)
-        auth_str = 'QBox ' + acctoken
+          acctoken = Qiniu::Auth.generate_acctoken(url, body)
+          auth_str = 'QBox ' + acctoken
 
-        false.should == Qiniu::Auth.authenticate_callback_request(auth_str + '  ', url, body)
-        true.should == Qiniu::Auth.authenticate_callback_request(auth_str, url, body)
-        true.should == Qiniu::Auth.authenticate_callback_request(acctoken, url, body)
+          false.should == Qiniu::Auth.authenticate_callback_request(auth_str + '  ', url, body)
+          true.should == Qiniu::Auth.authenticate_callback_request(auth_str, url, body)
+          true.should == Qiniu::Auth.authenticate_callback_request(acctoken, url, body)
+        end
       end
     end
   end # module Auth


### PR DESCRIPTION
It wasn't indented on the right level so it fell outside of the
`describe` block defined on line 12.

Problem can be seen here: https://travis-ci.org/qiniu/ruby-sdk/jobs/155867082