### PR TITLE
去除七牛ruby sdk 对mime-types 等版本依赖

### DIFF
--- a/qiniu.gemspec
+++ b/qiniu.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 12'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'webmock', '~> 2.3'
-  gem.add_runtime_dependency 'json', '~> 1.8'
-  gem.add_runtime_dependency 'rest-client', '~> 2.0', '>= 2.0.0'
-  gem.add_runtime_dependency 'mime-types', '~> 2.4', '>= 2.4.0'
+  gem.add_runtime_dependency 'json' 
+  gem.add_runtime_dependency 'rest-client' 
+  gem.add_runtime_dependency 'mime-types'
   gem.add_runtime_dependency 'jruby-openssl', '~> 0.7' if RUBY_PLATFORM == 'java'
 end


### PR DESCRIPTION
Bundler could not find compatible versions for gem 'mime-types'
e.g.
```
Bundler could not find compatible versions for gem "mime-types":
  In snapshot (Gemfile.lock):
    mime-types (= 3.1)

  In Gemfile:
    capybara was resolved to 2.8.1, which depends on
      mime-types (>= 1.16)

    capybara was resolved to 2.8.1, which depends on
      mime-types (>= 1.16)

    minitest-spec-rails was resolved to 5.4.0, which depends on
      rails (>= 4.1) was resolved to 5.0.1, which depends on
        actionmailer (= 5.0.1) was resolved to 5.0.1, which depends on
          mail (>= 2.5.4, ~> 2.5) was resolved to 2.6.4, which depends on
            mime-types (< 4, >= 1.16)

    qiniu (>= 6.9.0) was resolved to 6.9.0, which depends on
      mime-types (>= 2.4.0, ~> 2.4)

    weixin_authorize was resolved to 1.6.4, which depends on
      rest-client (>= 1.6.7) was resolved to 2.0.2, which depends on
        mime-types (< 4.0, >= 1.16)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```