### PR TITLE
bug fix - batch copy parameters format error

### DIFF
--- a/lib/qiniu/management.rb
+++ b/lib/qiniu/management.rb
@@ -94,7 +94,7 @@ module Qiniu
         end # batch_stat
 
         def batch_copy(*args)
-          _batch_cp_or_mv('copy', args)
+          _batch_cp_or_mv('copy', *args)
         end # batch_copy
 
         def batch_move(*args)

--- a/spec/qiniu/management_spec.rb
+++ b/spec/qiniu/management_spec.rb
@@ -62,7 +62,7 @@ module Qiniu
 
       context ".batch_copy" do
         it "should works" do
-          code, data = Storage.batch_copy @bucket, @key, @bucket, @key2
+          code, data = Storage.batch_copy [@bucket, @key, @bucket, @key2]
           puts data.inspect
           code.should == 200
 


### PR DESCRIPTION
修复：批量复制参数传递过程中的错误。

与批量移动修复错误相似：#142