### PR TITLE
Remove Ruby version limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,19 @@
 language: ruby
 rvm:
-- 2.1.10
-- 2.2.4
-- 2.6.0
-- ruby-head
-- jruby-9.0
-- jruby-head
+  - 2.4.0
+  - 2.6.0
+  - ruby-head
+  - jruby-9.0
+  - jruby-head
 before_script:
-- export IS_TRAVIS=true
+  - export IS_TRAVIS=true
 gemfile:
-- Gemfile
-- rails/Gemfile
+  - Gemfile
+  - rails/Gemfile
 env:
   global:
-  - QINIU_ACCESS_KEY=vHg2e7nOh7Jsucv2Azr5FH6omPgX22zoJRWa0FN5
-  - secure: Hc4PbrnMvVhWyOzG79LroswM60wj7Fr0kpCERLuA65Li2DW01sRYYQR61MXjATcBSqBbgn0ywBV/vWFP/1vxEeZfPuDXHpUxOtUxf57Y7Nsgs2KFQ4QlpYU3gDn2Qz/+KWoBZDNHTrlKuMC8l+pvEyJ2mN99q2Ap6EE188cpP5k=
+    - QINIU_ACCESS_KEY=vHg2e7nOh7Jsucv2Azr5FH6omPgX22zoJRWa0FN5
+    - secure: Hc4PbrnMvVhWyOzG79LroswM60wj7Fr0kpCERLuA65Li2DW01sRYYQR61MXjATcBSqBbgn0ywBV/vWFP/1vxEeZfPuDXHpUxOtUxf57Y7Nsgs2KFQ4QlpYU3gDn2Qz/+KWoBZDNHTrlKuMC8l+pvEyJ2mN99q2Ap6EE188cpP5k=
 deploy:
   provider: rubygems
   gem: qiniu

--- a/qiniu.gemspec
+++ b/qiniu.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Qiniu::Version.to_s
   gem.license       = 'MIT'
-  gem.required_ruby_version = '~> 2.1'
 
   # specify any dependencies here; for example:
   gem.add_development_dependency 'rake', '~> 12'


### PR DESCRIPTION
Ruby 3.0 即将发布，实际上 Gem 可以不用限制 Ruby 版本，目前社区绝大多数人都在使用 Ruby 2.x 以上的版本。